### PR TITLE
fix overwrite issues bandwith

### DIFF
--- a/ajax/bandwidth/get_bandwidth.php
+++ b/ajax/bandwidth/get_bandwidth.php
@@ -49,6 +49,7 @@ if ($timeunits === 'm') {
 }
 
 $datasizeunits = filter_input(INPUT_GET, 'dsu');
+$dsu_factor = $datasizeunits == "mb" ? 1024 * 1024 : 1024;
 header('X-Content-Type-Options: nosniff');
 header('Content-Type: application/json');
 echo '[ ';
@@ -73,13 +74,8 @@ for ($i = count($jsonData) - 1; $i >= 0; --$i) {
         echo ',';
     }
 
-    if ($datasizeunits == 'mb') {
-        $datasend = round($jsonData[$i]['tx'] / 1024, 0);
-        $datareceived = round($jsonData[$i]['rx'] / 1024, 0);
-    } else {
-        $datasend = $jsonData[$i]['rx'];
-        $datareceived = $jsonData[$i]['rx'];
-    }
+    $datasend = round($jsonData[$i]['tx'] / $dsu_factor, 0);
+    $datareceived = round($jsonData[$i]['rx'] / $dsu_factor, 0);
 
     if ($timeunits === 'm') {
         echo '{ "date": "' , $dt->format('Y-m') , '", "rx": "' , $datareceived , 

--- a/ajax/bandwidth/get_bandwidth_hourly.php
+++ b/ajax/bandwidth/get_bandwidth_hourly.php
@@ -39,11 +39,14 @@ if (filter_input(INPUT_GET, 'tu') == 'h') {
         exit('vnstat error');
     }
 
+    $datasizeunits = filter_input(INPUT_GET, 'dsu');
+    $dsu_factor = $datasizeunits == "mb" ? 1024 * 1024 : 1024;
+
     $jsonobj = json_decode($jsonstdoutvnstat[0], true)['interfaces'][0];
     $jsonData = $jsonobj['traffic']['hour'];
     for ($i = count($jsonData) - 1; $i >= 0 && $i >= count($jsonData)-25; --$i) {
-        $data_template[$jsonData[$i]['time']['hour']]['rx'] = round($jsonData[$i]['rx'] / 1024, 0);
-        $data_template[$jsonData[$i]['time']['hour']]['tx'] = round($jsonData[$i]['tx'] / 1024, 0);
+        $data_template[$jsonData[$i]['time']['hour']]['rx'] = round($jsonData[$i]['rx'] / $dsu_factor, 0);
+        $data_template[$jsonData[$i]['time']['hour']]['tx'] = round($jsonData[$i]['tx'] / $dsu_factor, 0);
     }
 
     $data = array();

--- a/ajax/bandwidth/get_bandwidth_hourly.php
+++ b/ajax/bandwidth/get_bandwidth_hourly.php
@@ -41,7 +41,7 @@ if (filter_input(INPUT_GET, 'tu') == 'h') {
 
     $jsonobj = json_decode($jsonstdoutvnstat[0], true)['interfaces'][0];
     $jsonData = $jsonobj['traffic']['hour'];
-    for ($i = count($jsonData) - 1; $i >= 0; --$i) {
+    for ($i = count($jsonData) - 1; $i >= 0 && $i >= count($jsonData)-25; --$i) {
         $data_template[$jsonData[$i]['time']['hour']]['rx'] = round($jsonData[$i]['rx'] / 1024, 0);
         $data_template[$jsonData[$i]['time']['hour']]['tx'] = round($jsonData[$i]['tx'] / 1024, 0);
     }


### PR DESCRIPTION
The $jsonobj array is iterated from the back, so the first entries overwrite the newest entries (that is, the ones from the back). So it happens that instead of the traffic for today 16 o'clock ,the traffic from the day before yesterday 16 o'clock ends up in the array $data_template and is displayed in the graph. But this should not be like this!